### PR TITLE
bump SSZipArchive to 2.1.4 to get memcpy fix

### DIFF
--- a/Specs/2/1/2/SSZipArchive/2.1.4/SSZipArchive.podspec.json
+++ b/Specs/2/1/2/SSZipArchive/2.1.4/SSZipArchive.podspec.json
@@ -1,0 +1,33 @@
+{
+  "name": "SSZipArchive",
+  "version": "2.1.4",
+  "summary": "Utility class for zipping and unzipping files on iOS, tvOS, watchOS, and Mac.",
+  "description": "SSZipArchive is a simple utility class for zipping and unzipping files on iOS, tvOS, watchOS, and Mac.",
+  "homepage": "https://github.com/ZipArchive/ZipArchive",
+  "license": {
+    "type": "MIT",
+    "file": "LICENSE.txt"
+  },
+  "authors": {
+    "Sam Soffes": "sam@soff.es",
+    "Joshua Hudson": null,
+    "Antoine Cœur": null
+  },
+  "source": {
+    "git": "https://github.com/ZipArchive/ZipArchive.git",
+    "tag": "v2.1.4"
+  },
+  "platforms": {
+    "ios": "4.3",
+    "tvos": "9.0",
+    "osx": "10.8",
+    "watchos": "2.0"
+  },
+  "source_files": [
+    "SSZipArchive/*.{m,h}",
+    "SSZipArchive/minizip/*.{c,h}",
+    "SSZipArchive/minizip/aes/*.{c,h}"
+  ],
+  "public_header_files": "SSZipArchive/*.h",
+  "libraries": "z"
+}


### PR DESCRIPTION
Let me test a build with 2.1.4 first.