### PR TITLE
make Eureka 4.3.0 available

### DIFF
--- a/Specs/3/a/8/Eureka/4.3.0/Eureka.podspec.json
+++ b/Specs/3/a/8/Eureka/4.3.0/Eureka.podspec.json
@@ -1,0 +1,28 @@
+{
+  "name": "Eureka",
+  "version": "4.3.0",
+  "license": "MIT",
+  "summary": "Elegant iOS Forms in pure Swift",
+  "homepage": "https://github.com/xmartlabs/Eureka",
+  "social_media_url": "http://twitter.com/xmartlabs",
+  "authors": {
+    "Martin Barreto": "martin@xmartlabs.com",
+    "Mathias Claassen": "mathias@xmartlabs.com"
+  },
+  "source": {
+    "git": "https://github.com/xmartlabs/Eureka.git",
+    "tag": "4.3.0"
+  },
+  "platforms": {
+    "ios": "8.0"
+  },
+  "ios": {
+    "frameworks": [
+      "UIKit",
+      "Foundation"
+    ]
+  },
+  "source_files": "Source/**/*.swift",
+  "resources": "Source/Resources/Eureka.bundle",
+  "requires_arc": true
+}


### PR DESCRIPTION
Sorry about the noise. We manually copied over the main Cocoapod spec repo’s `4.3.0/Eureka.podspec.json`. We changed the iOS repo’s Podfile to point to my fork and we were able to update Eureka.

This is for converting to Swift 4.2. Xcode is supposed to support compiling with Swift 4.2 while some targets still compile with older version of Swift, but circle doesn’t seem to support that.